### PR TITLE
Fix crashes with mod berries extending Strawberry

### DIFF
--- a/CelesteTAS-EverestInterop/everest.yaml
+++ b/CelesteTAS-EverestInterop/everest.yaml
@@ -1,5 +1,5 @@
 - Name: CelesteTAS
-  Version: 2.0.4
+  Version: 2.0.5
   DLL: CelesteTAS-EverestInterop.dll
   Dependencies:
     - Name: Everest


### PR DESCRIPTION
Mod berries extending Strawberry don't necessarily have their own `collectTimer` field, making the game crash when the TAS tools are enabled.

This PR makes the TAS tools read `collectTimer` from the parent class (Strawberry) if it doesn't exist in the strawberry's actual type.