### PR TITLE
Don't play sounds when they are 'auto-muted' (fast-forwarding)

### DIFF
--- a/CelesteTAS-EverestInterop/EverestInterop/AutoMute.cs
+++ b/CelesteTAS-EverestInterop/EverestInterop/AutoMute.cs
@@ -8,6 +8,8 @@ namespace TAS.EverestInterop {
         public static AutoMute instance;
         private int? lastSFXVolume;
 
+        private EventInstance dummy;
+
         public void Load() {
             On.Monocle.Scene.Update += SceneOnUpdate;
             On.Celeste.SoundSource.Play += SoundSourceOnPlay;
@@ -28,52 +30,57 @@ namespace TAS.EverestInterop {
                 AudioOnPlay_string_Vector2_string_float_string_float;
         }
 
+        private EventInstance getDummyEventInstance() {
+            if (dummy == null) {
+                // this sound does exist, but is silent if we don't set any audio param to it.
+                dummy = Audio.CreateInstance("event:/char/madeline/footstep");
+                dummy.setVolume(0);
+            }
+            return dummy;
+        }
+
         private EventInstance AudioOnPlay_string_string_float(On.Celeste.Audio.orig_Play_string_string_float orig,
             string path, string param, float value) {
-            EventInstance eventInstance = orig(path, param, value);
             if (Manager.FrameLoops >= 2) {
-                eventInstance?.setVolume(0);
+                return getDummyEventInstance();
             }
 
-            return eventInstance;
+            return orig(path, param, value);
         }
 
         private EventInstance AudioOnPlay_string_Vector2_string_float_string_float(
             On.Celeste.Audio.orig_Play_string_Vector2_string_float_string_float orig, string path, Vector2 position,
             string param, float value, string param2, float value2) {
-            EventInstance eventInstance = orig(path, position, param, value, param2, value2);
             if (Manager.FrameLoops >= 2) {
-                eventInstance?.setVolume(0);
+                return getDummyEventInstance();
             }
 
-            return eventInstance;
+            return orig(path, position, param, value, param2, value2);
         }
 
         private EventInstance AudioOnPlay_string_Vector2(On.Celeste.Audio.orig_Play_string_Vector2 orig, string path,
             Vector2 position) {
-            EventInstance eventInstance = orig(path, position);
             if (Manager.FrameLoops >= 2) {
-                eventInstance?.setVolume(0);
+                return getDummyEventInstance();
             }
 
-            return eventInstance;
+            return orig(path, position);
         }
 
         private EventInstance AudioOnPlay_string(On.Celeste.Audio.orig_Play_string orig, string path) {
-            EventInstance eventInstance = orig(path);
             if (Manager.FrameLoops >= 2) {
-                eventInstance?.setVolume(0);
+                return getDummyEventInstance();
             }
 
-            return eventInstance;
+            return orig(path);
         }
 
         private SoundSource SoundSourceOnPlay(On.Celeste.SoundSource.orig_Play orig, SoundSource self, string path,
             string param, float value) {
             if (Manager.FrameLoops >= 2) {
-                path = "";
+                return self;
             }
-            
+
             return orig(self, path, param, value);
         }
 


### PR DESCRIPTION
This PR changes the "auto-mute" class so that it doesn't play sounds by not calling orig methods, instead of playing the sounds but muted. When the method should return an EventInstance, we return a shared instance of an existing vanilla sound that is silent unless you set the proper audio params on it (the footstep sound). SoundSource.Play returns `self`, since the original method does the same (it returns `this`).

This was done after reports of freezes during fast-forwarding: the freeze points were calls to FMOD, that eventually get stuck. FMOD getting overloaded can actually be heard, since music progressively stutters / gets distorted before eventually becoming silent - and that's when the fast forward starts freezing as well. 