### PR TITLE
Wrap the benchmark with JetBrains profiler api for more accurate result

### DIFF
--- a/CelesteTAS-EverestInterop/CelesteTAS-EverestInterop.csproj
+++ b/CelesteTAS-EverestInterop/CelesteTAS-EverestInterop.csproj
@@ -41,6 +41,9 @@
         <PackageReference Include="MonoMod" Version="21.4.29.1" />
         <PackageReference Include="MonoMod.RuntimeDetour" Version="21.4.29.1" />
         <PackageReference Include="MonoMod.Utils" Version="21.4.29.1" />
+        <PackageReference Include="JetBrains.Profiler.Api" Version="1.1.8">
+            <IncludeAssets Condition="'$(Configuration)' == 'Debug'">all</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <Reference Include="Celeste">

--- a/CelesteTAS-EverestInterop/EverestInterop/Benchmark.cs
+++ b/CelesteTAS-EverestInterop/EverestInterop/Benchmark.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using JetBrains.Profiler.Api;
 using Microsoft.Xna.Framework;
 using Monocle;
 using TAS.Input;
@@ -48,9 +49,11 @@ namespace TAS.EverestInterop {
             lastFrameCounter = Engine.FrameCounter;
             watch.Restart();
             $"Benchmark Start: {InputController.TasFilePath}".Log();
+            MeasureProfiler.StartCollectingData();
         }
 
         private static void Stop() {
+            MeasureProfiler.SaveData();
             ulong frames = Engine.FrameCounter - lastFrameCounter;
             float framesPerSecond = (int) Math.Round(1 / Engine.RawDeltaTime);
             $"Benchmark Stop: frames={frames} time={watch.ElapsedMilliseconds}ms avg_speed={frames / framesPerSecond / watch.ElapsedMilliseconds * 1000f}"


### PR DESCRIPTION
This allows auto start and stop profiling when benchmarking with profiler opened