### PR TITLE
feat: add "Mouse" command for mouse support

### DIFF
--- a/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/MouseCommand.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/MouseCommand.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Monocle;
+using TAS.Utils;
+
+namespace TAS.Input.Commands;
+
+public static class MouseCommand {
+    public static Point? Position { get; private set; } = null;
+
+    // "Mouse, X, Y",
+    [TasCommand("Mouse")]
+    private static void Press(string[] args) {
+        if (args.IsEmpty()) {
+            return;
+        }
+
+        if (!int.TryParse(args[0], out int x) || x > 320 || x < 0) {
+            AbortTas($"{args[0]} is not a valid X position");
+            return;
+        }
+
+        if (!int.TryParse(args[1], out int y) || y > 320 || y < 0) {
+            AbortTas($"{args[1]} is not a valid Y position");
+            return;
+        }
+
+        var win = Engine.Instance.Window.ClientBounds;
+        if ((win.Width % 320) != 0 || (win.Height % 180) != 0) {
+            AbortTas("Window size isn't an integer multiple of 320x180");
+            return;
+        }
+
+        Position = new Point(x, y);
+    }
+
+    [DisableRun]
+    private static void DisableRun() {
+        Position = null;
+    }
+
+    public static Point? GetPosition() {
+        if (Manager.Controller.Current != Manager.Controller.Next) {
+            Position = null;
+        }
+
+        return Position;
+    }
+}

--- a/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/MouseCommand.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/MouseCommand.cs
@@ -9,20 +9,21 @@ namespace TAS.Input.Commands;
 
 public static class MouseCommand {
     public static Point? Position { get; private set; } = null;
+    public static bool Click;
 
     // "Mouse, X, Y",
     [TasCommand("Mouse")]
-    private static void Press(string[] args) {
+    private static void Move(string[] args) {
         if (args.IsEmpty()) {
             return;
         }
 
-        if (!int.TryParse(args[0], out int x) || x > 320 || x < 0) {
+        if (!int.TryParse(args[0], out int x) || x > 319 || x < 0) {
             AbortTas($"{args[0]} is not a valid X position");
             return;
         }
 
-        if (!int.TryParse(args[1], out int y) || y > 180 || y < 0) {
+        if (!int.TryParse(args[1], out int y) || y > 179 || y < 0) {
             AbortTas($"{args[1]} is not a valid Y position");
             return;
         }

--- a/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/MouseCommand.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/MouseCommand.cs
@@ -22,7 +22,7 @@ public static class MouseCommand {
             return;
         }
 
-        if (!int.TryParse(args[1], out int y) || y > 320 || y < 0) {
+        if (!int.TryParse(args[1], out int y) || y > 180 || y < 0) {
             AbortTas($"{args[1]} is not a valid Y position");
             return;
         }

--- a/CelesteTAS-EverestInterop/Source/TAS/Manager.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Manager.cs
@@ -275,25 +275,10 @@ public static class Manager {
         gamePadData.PreviousState = gamePadData.CurrentState;
         gamePadData.CurrentState = gamePadState;
 
-        SetMouseState();
+        MouseCommand.SetMouseState();
         SetKeyboardState(input);
 
         MInput.UpdateVirtualInputs();
-    }
-
-    private static void SetMouseState() {
-        MInput.Mouse.PreviousState = MInput.Mouse.CurrentState;
-        
-        var buttons = MouseCommand.GetButtons();
-
-        MInput.Mouse.CurrentState = new MouseState(
-            MouseCommand.Position.X, MouseCommand.Position.Y,
-            MInput.Mouse.PreviousState.ScrollWheelValue,
-            buttons[MouseCommand.MINDEX_LFTBTN],
-            buttons[MouseCommand.MINDEX_MIDBTN],
-            buttons[MouseCommand.MINDEX_RITBTN],
-            ButtonState.Released, ButtonState.Released
-        );
     }
 
     private static void SetKeyboardState(InputFrame input) {

--- a/CelesteTAS-EverestInterop/Source/TAS/Manager.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Manager.cs
@@ -275,20 +275,25 @@ public static class Manager {
         gamePadData.PreviousState = gamePadData.CurrentState;
         gamePadData.CurrentState = gamePadState;
 
-        SetMousePosition();
+        SetMouseState();
         SetKeyboardState(input);
 
         MInput.UpdateVirtualInputs();
     }
 
-    private static void SetMousePosition() {
-        Point? pos = MouseCommand.GetPosition();
-        if (pos.HasValue) {
-            int scale = Engine.Instance.Window.ClientBounds.Width / 320;
-            int x = pos.Value.X * scale;
-            int y = pos.Value.Y * scale;
-            Mouse.SetPosition(x, y);
-        }
+    private static void SetMouseState() {
+        MInput.Mouse.PreviousState = MInput.Mouse.CurrentState;
+        
+        var buttons = MouseCommand.GetButtons();
+
+        MInput.Mouse.CurrentState = new MouseState(
+            MouseCommand.Position.X, MouseCommand.Position.Y,
+            MInput.Mouse.PreviousState.ScrollWheelValue,
+            buttons[MouseCommand.MINDEX_LFTBTN],
+            buttons[MouseCommand.MINDEX_MIDBTN],
+            buttons[MouseCommand.MINDEX_RITBTN],
+            ButtonState.Released, ButtonState.Released
+        );
     }
 
     private static void SetKeyboardState(InputFrame input) {

--- a/CelesteTAS-EverestInterop/Source/TAS/Manager.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Manager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -275,9 +275,20 @@ public static class Manager {
         gamePadData.PreviousState = gamePadData.CurrentState;
         gamePadData.CurrentState = gamePadState;
 
+        SetMousePosition();
         SetKeyboardState(input);
 
         MInput.UpdateVirtualInputs();
+    }
+
+    private static void SetMousePosition() {
+        Point? pos = MouseCommand.GetPosition();
+        if (pos.HasValue) {
+            int scale = Engine.Instance.Window.ClientBounds.Width / 320;
+            int x = pos.Value.X * scale;
+            int y = pos.Value.Y * scale;
+            Mouse.SetPosition(x, y);
+        }
     }
 
     private static void SetKeyboardState(InputFrame input) {

--- a/CelesteTAS-EverestInterop/Source/Utils/SpeedrunToolUtils.cs
+++ b/CelesteTAS-EverestInterop/Source/Utils/SpeedrunToolUtils.cs
@@ -23,6 +23,7 @@ internal static class SpeedrunToolUtils {
     private static int waitingFrames;
     private static HashSet<Keys> pressKeys;
     private static long? tasStartFileTime;
+    private static MouseState mouseState;
 
     public static void AddSaveLoadAction() {
         Action<Dictionary<Type, Dictionary<string, object>>, Level> save = (_, _) => {
@@ -35,6 +36,7 @@ internal static class SpeedrunToolUtils {
             waitingFrames = StunPauseCommand.WaitingFrames;
             pressKeys = PressCommand.PressKeys.DeepCloneShared();
             tasStartFileTime = MetadataCommands.TasStartFileTime;
+            mouseState = MouseCommand.CurrentState;
         };
         Action<Dictionary<Type, Dictionary<string, object>>, Level> load = (_, _) => {
             EntityDataHelper.CachedEntityData = savedEntityData.DeepCloneShared();
@@ -50,6 +52,7 @@ internal static class SpeedrunToolUtils {
             }
 
             MetadataCommands.TasStartFileTime = tasStartFileTime;
+            MouseCommand.CurrentState = mouseState;
         };
         Action clear = () => {
             savedEntityData.Clear();


### PR DESCRIPTION
The added "Mouse" command takes x and y coordinates within a 320x180 input space and moves the mouse accordingly. To avoid desyncs, the command only runs on window sizes that are integer upscales of the game's original 320x180 size.
Edit: Now supports clicking/holding left, middle and right mouse buttons.