### PR TITLE
Improve custom keybind support

### DIFF
--- a/CelesteTAS-EverestInterop/Source/TAS/BindingHelper.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/BindingHelper.cs
@@ -82,18 +82,6 @@ public static class BindingHelper {
 
         origAttached = MInput.GamePads[GameInput.Gamepad].Attached;
         MInput.GamePads[GameInput.Gamepad].Attached = true;
-        
-        foreach (EverestModule module in Everest.Modules) {
-            if (module.SettingsType != null && module._Settings is { } settings and not CelesteTasSettings) {
-                foreach (PropertyInfo propertyInfo in module.SettingsType.GetAllProperties()) {
-                    if (propertyInfo.GetGetMethod(true) == null || propertyInfo.GetSetMethod(true) == null || propertyInfo.PropertyType != typeof(ButtonBinding) || propertyInfo.GetValue(settings) is not ButtonBinding buttonBinding) {
-                        continue;
-                    }
-
-                    buttonBinding.Button.Binding = new Binding();
-                }
-            }
-        }
     }
 
     // ReSharper disable once UnusedMember.Local
@@ -173,6 +161,18 @@ public static class BindingHelper {
         SetBinding("DownMoveOnly");
 
         GameInput.Initialize();
+
+        foreach (EverestModule module in Everest.Modules) {
+            if (module.SettingsType != null && module._Settings is { } settings and not CelesteTasSettings) {
+                foreach (PropertyInfo propertyInfo in module.SettingsType.GetAllProperties()) {
+                    if (propertyInfo.GetGetMethod(true) == null || propertyInfo.GetSetMethod(true) == null || propertyInfo.PropertyType != typeof(ButtonBinding) || propertyInfo.GetValue(settings) is not ButtonBinding buttonBinding) {
+                        continue;
+                    }
+
+                    buttonBinding.Button.Binding = new Binding();
+                }
+            }
+        }
     }
 
     private static void SetBinding(string fieldName, params Buttons[] buttons) {

--- a/CelesteTAS-EverestInterop/Source/TAS/BindingHelper.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/BindingHelper.cs
@@ -7,6 +7,7 @@ using Celeste.Mod.Core;
 using Microsoft.Xna.Framework.Input;
 using Monocle;
 using MonoMod.Utils;
+using TAS.Module;
 using TAS.Utils;
 using GameInput = Celeste.Input;
 
@@ -47,7 +48,7 @@ public static class BindingHelper {
     public static Buttons RightDashOnly { get; } = Buttons.RightThumbstickRight;
     public static Buttons UpDashOnly { get; } = Buttons.RightThumbstickUp;
     public static Buttons DownDashOnly { get; } = Buttons.RightThumbstickDown;
-    public static Keys Confirm2 => Keys.C;
+    public static Keys Confirm2 => Keys.NumPad0;
     private static bool? origControllerHasFocus;
     private static bool origKbTextInput;
     private static bool origAttached;
@@ -81,6 +82,18 @@ public static class BindingHelper {
 
         origAttached = MInput.GamePads[GameInput.Gamepad].Attached;
         MInput.GamePads[GameInput.Gamepad].Attached = true;
+        
+        foreach (EverestModule module in Everest.Modules) {
+            if (module.SettingsType != null && module._Settings is { } settings and not CelesteTasSettings) {
+                foreach (PropertyInfo propertyInfo in module.SettingsType.GetAllProperties()) {
+                    if (propertyInfo.GetGetMethod(true) == null || propertyInfo.GetSetMethod(true) == null || propertyInfo.PropertyType != typeof(ButtonBinding) || propertyInfo.GetValue(settings) is not ButtonBinding buttonBinding) {
+                        continue;
+                    }
+
+                    buttonBinding.Button.Binding = new Binding();
+                }
+            }
+        }
     }
 
     // ReSharper disable once UnusedMember.Local

--- a/CelesteTAS-EverestInterop/Source/TAS/Manager.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Manager.cs
@@ -287,6 +287,7 @@ public static class Manager {
         if (input.HasActions(Actions.Confirm)) {
             keys.Add(BindingHelper.Confirm2);
         }
+        keys.UnionWith(input.PressedKeys);
 
         MInput.Keyboard.CurrentState = new KeyboardState(keys.ToArray());
     }

--- a/Docs/Commands.md
+++ b/Docs/Commands.md
@@ -89,7 +89,7 @@
   - `Set, CelesteTAS.CenterCamera, true`
   - `Set, AnarchyCollab2022.LeftButton, Q, W`
 
-    Set helper's button, only keyboard keys are supported. Then you can use [Press](#press) command to press them.
+    Set helper's button, only keyboard keys are supported. Then you can use the `P` custom key press modifier or the [Press](#press) command to press them.
     The setting is only valid when tas is running, it will be restored automatically when tas is stopped.
 
 ### Invoke

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ e.g. 123,R,J (For 123 frames, hold Right and Jump)
 - O = Confirm Bind 2
 - N = Journal / Talk Bind 2
 - A = Dash Only Directional Modifier (generally used to manipulate camera with binocular control storage. eg: 15 R,X,ALU)
+- P = Custom Button Press Modifier (used to press inputs added by mods after binding them using the [Set command](Docs/Commands.md#set), e.g. 15 R,X,PA after binding A to a custom input)
 
 ## Controls
 While in game or in Studio:

--- a/Studio/Studio.cs
+++ b/Studio/Studio.cs
@@ -1258,7 +1258,11 @@ public partial class Studio : BaseForm {
                             index = newInput.HasActions(Actions.Feather) ? formattedText.Length : 4;
 
                             if (!oldInput.HasActions(Actions.DashOnly) && newInput.HasActions(Actions.DashOnly)) {
-                                index = formattedText.Length;
+                                index = formattedText.IndexOf(",A", StringComparison.InvariantCultureIgnoreCase) + 2;
+                            }
+
+                            if (!oldInput.HasActions(Actions.PressedKey) && newInput.HasActions(Actions.PressedKey)) {
+                                index = formattedText.IndexOf(",P", StringComparison.InvariantCultureIgnoreCase) + 2;
                             }
                         }
 

--- a/Studio/Studio.cs
+++ b/Studio/Studio.cs
@@ -1021,7 +1021,7 @@ public partial class Studio : BaseForm {
 
             while (end < InputRecords.Count - 1) {
                 InputRecord next = InputRecords[end + 1];
-                if ((next.IsInput || next.IsEmpty) && next.Actions == currentRecord.Actions) {
+                if ((next.IsInput || next.IsEmpty) && next.Actions == currentRecord.Actions && next.PressedKeys.SetEquals(currentRecord.PressedKeys)) {
                     end++;
                 } else {
                     break;


### PR DESCRIPTION
The recent addition of the `Press` command has made TASing maps with custom inputs much easier, but they still somewhat break the flow of the TAS file and have a few other issues. This PR aims to improve the way custom inputs are handled.

The main feature of this PR is a new syntax for pressing custom inputs. The bindings are still set using the `Set` command, but they can now also be pressed in a normal input line using the `P` prefix (e.g. 15 R,X,PA presses the `A` button in addition to right and dash).
This PR also prevents custom inputs from interfering with any existing bindings by clearing all modded bindings when the TAS is run (they are restored when playback ends). Additionally, it moves the internal keybinding for the second confirm key from C to Numpad0 to prevent a confirm being triggered by `Press,C` or `PC`.

I am submitting this as a draft for now, mainly because I am unable to build Studio on my machine, so the Studio changes are currently untested.
The only other concern is how this PR interacts with the legacy method of handling a few custom inputs by binding them to lesser-used actions. I'm not sure how exactly that functions, and this PR might break it (though it's probably also used so little that breaking backwards compatibility for it is not a huge deal).