### PR TITLE
Optimize puffer hitbox render

### DIFF
--- a/CelesteTAS-EverestInterop/Source/EverestInterop/Hitboxes/HitboxColor.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/Hitboxes/HitboxColor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Celeste;

--- a/CelesteTAS-EverestInterop/Source/EverestInterop/Hitboxes/HitboxColor.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/Hitboxes/HitboxColor.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Celeste;
@@ -16,6 +17,8 @@ public static class HitboxColor {
     public static readonly Color DefaultTriggerColor = Color.MediumPurple;
     public static readonly Color DefaultPlatformColor = Color.Coral;
     public static readonly Color RespawnTriggerColor = Color.YellowGreen;
+    public static readonly Color PufferHeightCheckColor = Color.WhiteSmoke;
+    public static readonly Color PufferPushRadiusColor = Color.DarkRed;
 
     private static readonly Regex HexChar = new(@"^[0-9a-f]*$", RegexOptions.IgnoreCase);
 

--- a/CelesteTAS-EverestInterop/Source/EverestInterop/Hitboxes/HitboxOptimized.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/Hitboxes/HitboxOptimized.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Celeste;
 using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
@@ -105,16 +106,40 @@ public static class HitboxOptimized {
     }
 
     private static void DrawPufferHitbox(Puffer puffer) {
-        Vector2 bottomCenter = puffer.BottomCenter - Vector2.UnitY * 1;
-        if (puffer.Scene.Tracker.GetEntity<Player>() is {Ducking: true}) {
-            bottomCenter -= Vector2.UnitY * 3;
-        }
+        /*
+         * ProximityExplodeCheck: player.CenterY >= base.Y + collider.Bottom - 4f
+         * OnPlayer Explode: player.Bottom > lastSpeedPosition.Y + 3f
+         * 
+         * CenterY can be half integer if crouched
+         * base.Y is not integer
+         * laseSpeedPosition is not integer
+         * 
+         * Draw.Line: round to integer, plus an annoying offset depending on angle
+         * Draw.Rect: trunc to integer, quite stable
+         */
 
+        /*
+         * we pretend we are using Hurtbox in collide check, and assume Player's position is on grid
+         * b = Hurtbox.Bottom = [player's Position] + ...
+         * b'= Rendered Hurtbox Bottom = b - 1
+         * c = player.CenterY = [player's Position] + (Hitbox.Top + Hitbox.Height/2)
+         * int i = height of Draw.Line
+         * i - b + c >= base.Y + collider.Bottom - 4f = puffer.Bottom - 4f
+         * i = Ceil(puffer.Bottom - 4f + b' - c)
+         * 
+         * in some weird cases, maddy can have starFlyHitbox + normalHurtbox...so we can't just check Ducking and StateMachine.State == 19
+         */
+
+        var player = puffer.Scene.Tracker.GetEntity<Player>();
+        float b = player?.hurtbox.Bottom ?? -2f;
+        float c = player?.collider.CenterY ?? -5.5f;
+        Vector2 bottomCenter = new Vector2(puffer.CenterX, (float) Math.Ceiling(puffer.Bottom - 5f + b - c));
         Color hitboxColor = HitboxColor.GetCustomColor(puffer);
-
         Draw.Circle(puffer.Position, 32f, hitboxColor, 32);
-        Draw.Line(bottomCenter - Vector2.UnitX * 32, bottomCenter - Vector2.UnitX * 6, hitboxColor);
-        Draw.Line(bottomCenter + Vector2.UnitX * 6, bottomCenter + Vector2.UnitX * 32, hitboxColor);
+        Color heightCheckColor = HitboxColor.PufferHeightCheckColor * (puffer.Collidable ? 1f : HitboxColor.UnCollidableAlpha);
+        Draw.Rect(bottomCenter.X - 7, bottomCenter.Y, -25f, 1f, heightCheckColor);
+        Draw.Rect(bottomCenter.X + 7, bottomCenter.Y, 25f, 1f, heightCheckColor);
+        // sometimes it will draw an extra pixel at the endpoint..
     }
 
     private static void DrawSwitchGateEnd(SwitchGate gate) {
@@ -262,7 +287,7 @@ public static class HitboxOptimized {
 
     private static void AddPufferPushRadius() {
         foreach (Circle circle in pufferPushRadius) {
-            Draw.Circle(circle.Position, circle.Radius, Color.DarkRed, 4);
+            Draw.Circle(circle.Position, circle.Radius, HitboxColor.PufferPushRadiusColor, 4);
         }
 
         if (Engine.FreezeTimer <= 0f) {
@@ -279,6 +304,26 @@ public static class HitboxOptimized {
             ilCursor
                 .Emit(OpCodes.Ldarg_0)
                 .EmitDelegate<Func<Color, Component, Color>>(OptimizePlayerColliderHitbox);
+            ilCursor.Index++;
+            ilCursor.Emit(OpCodes.Ldarg_0).EmitDelegate(OptimizePufferPlayerCollider);
+        }
+    }
+
+    private static void OptimizePufferPlayerCollider(Component component) {
+        if (component.Entity is not Puffer puffer || component is not PlayerCollider pc) {
+            return;
+        }
+        if (typeof(Puffer).CreateGetDelegate<Puffer,Vector2>("lastSpeedPosition") is { } getLastSpeedPosition) {
+            float y = getLastSpeedPosition.Invoke(puffer).Y + 3f - 1f;
+            float z = (float)Math.Ceiling(y);
+            if (z <= y) {
+                z+= 1f;
+            }
+            if (z > pc.Collider.AbsoluteBottom) {
+                return;
+            }
+            float top = Math.Max(pc.Collider.AbsoluteTop,z);
+            Draw.HollowRect(puffer.X - 7f, top, 14f, pc.Collider.AbsoluteBottom - top, puffer.Collidable ? HitboxColor.PufferHeightCheckColor : HitboxColor.PufferHeightCheckColor * HitboxColor.UnCollidableAlpha);
         }
     }
 


### PR DESCRIPTION
(1).Add a more accurate hitbox indicator on puffer's PlayerCollider where player can launch/bounce
(2).Make the height check line more accurate

About (1): puffer's Explode() is also called in OnPlayer(..), and the condition is
`player.Bottom > lastSpeedPosition.Y + 3f`
different from that in puffer's ProximityExplodeCheck().
https://discord.com/channels/403698615446536203/519281383164739594/1108956272734240820

About (2): puffer's Position.Y is not integer, so the previous "when ducking, bottomCenter -= Vector2.UnitY * 3" (which should be 2.5 instead of 3) has bug (I've found such example).
Moreover, starflyHit/Hurtbox are not considered in previous implementation.

This PR addresses above issues.