### PR TITLE
Bugfix: in InfoCustom, empty memberNames crashes the game

### DIFF
--- a/CelesteTAS-EverestInterop/Source/EverestInterop/InfoHUD/InfoCustom.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/InfoHUD/InfoCustom.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using Celeste;
@@ -22,6 +23,11 @@ public static class InfoCustom {
     private static readonly Dictionary<string, List<Type>> CachedParsedTypes = new();
     private static bool DisableParameterlessMethod => TAS.Input.Commands.EnforceLegalCommand.EnabledWhenRunning;
 
+    public delegate bool HelperMethod(object obj, int decimals, out string formattedValue);
+    // return true if obj is of expected parameter type. otherwise we call AutoFormatter
+    private static Dictionary<string, HelperMethod> HelperMethods = new();
+
+
     [Initialize]
     private static void CollectAllTypeInfo() {
         AllTypes.Clear();
@@ -31,6 +37,13 @@ public static class InfoCustom {
                 AllTypes[$"{type.FullName}@{type.Assembly.GetName().Name}"] = type;
             }
         }
+    }
+
+    [Initialize]
+    private static void InitializeHelperMethods() {
+        HelperMethods.Add("toFrame()", HelperMethod_toFrame);
+        HelperMethods.Add("toPixelPerFrame()", HelperMethod_toPixelPerFrame);
+        HelperMethods.Add("GetAssembly()", HelperMethod_GetAssembly);
     }
 
     public static string GetInfo(int? decimals = null) {
@@ -78,7 +91,7 @@ public static class InfoCustom {
             }
 
             string helperMethod = "";
-            if (lastMemberName is "toFrame()" or "toPixelPerFrame()") {
+            if (HelperMethods.ContainsKey(lastMemberName)) {
                 helperMethod = lastMemberName;
                 memberNames = memberNames.SkipLast().ToList();
             }
@@ -87,7 +100,11 @@ public static class InfoCustom {
                 .SelectMany(type => GetCachedOrFindEntities(type, entityId, cachedEntities)).Count() > 1;
 
             List<string> result = types.Select(type => {
-                if (type.GetGetMethod(memberNames.First()) is {IsStatic: true} || type.GetFieldInfo(memberNames.First()) is {IsStatic: true} || (MethodRegex.Match(memberNames.First()) is { Success: true } match && type.GetMethodInfo(match.Groups[1].Value) is {IsStatic: true })) {
+                if (memberNames.IsNotEmpty() && (
+                    type.GetGetMethod(memberNames.First()) is { IsStatic: true } || 
+                    type.GetFieldInfo(memberNames.First()) is { IsStatic: true } || 
+                    (MethodRegex.Match(memberNames.First()) is { Success: true } match && type.GetMethodInfo(match.Groups[1].Value) is { IsStatic: true })
+                    )) {
                     return FormatValue(GetMemberValue(type, null, memberNames), helperMethod, decimals);
                 }
 
@@ -117,7 +134,7 @@ public static class InfoCustom {
                     } else if (type == typeof(Session)) {
                         return FormatValue(GetMemberValue(type, level.Session, memberNames), helperMethod, decimals);
                     } else {
-                        return $"{type.FullName}.{memberNames.First()} member not found";
+                        return $"Instance of {type.FullName} not found";
                     }
                 }
 
@@ -240,45 +257,6 @@ public static class InfoCustom {
         }
     }
 
-    private static string FormatValue(object obj, string helperMethod, int decimals) {
-        if (obj == null) {
-            return string.Empty;
-        }
-
-        if (obj is Vector2 vector2) {
-            if (helperMethod == "toPixelPerFrame()") {
-                vector2 = GameInfo.ConvertSpeedUnit(vector2, SpeedUnit.PixelPerFrame);
-            }
-
-            return vector2.ToSimpleString(decimals);
-        }
-
-        if (obj is Vector2Double vector2Double) {
-            return vector2Double.ToSimpleString(decimals);
-        }
-
-        if (obj is float floatValue) {
-            if (helperMethod == "toFrame()") {
-                return GameInfo.ConvertToFrames(floatValue).ToString();
-            } else if (helperMethod == "toPixelPerFrame()") {
-                return GameInfo.ConvertSpeedUnit(floatValue, SpeedUnit.PixelPerFrame).ToString(CultureInfo.InvariantCulture);
-            } else {
-                return floatValue.ToFormattedString(decimals);
-            }
-        }
-        if (obj is Entity entity) {
-            string id = entity.GetEntityData()?.ToEntityId().ToString() is { } value ? $"[{value}]" : "";
-            return $"{entity.ToString()}{id}";
-        }
-        if (obj is IEnumerable enumerable and not IEnumerable<char>) {
-            bool compressed = enumerable is IEnumerable<Component> or IEnumerable<Entity>;
-            string separator = compressed ? ",\n " : ", ";
-            return IEnumerableToString(enumerable, separator, compressed);
-        }
-
-        return obj.ToString();
-    }
-
     public static object GetMemberValue(Type type, object obj, List<string> memberNames, bool setCommand = false) {
         foreach (string memberName in memberNames) {
             if (type.GetGetMethod(memberName) is { } getMethodInfo) {
@@ -351,6 +329,79 @@ public static class InfoCustom {
         }
     }
 
+    public static string FormatValue(object obj, string helperMethodName, int decimals) {
+        if (obj == null) {
+            return string.Empty;
+        }
+
+        bool InvalidParameter = false;
+        if (HelperMethods.TryGetValue(helperMethodName, out HelperMethod method)) {
+            if (method(obj, decimals, out string formattedValue)) {
+                return formattedValue;
+            } else {
+                InvalidParameter = true;
+            }
+        }
+
+        return $"{AutoFormatter(obj, decimals)}{(InvalidParameter ? $",\n not a valid parameter of {helperMethodName}" : "")}";
+    }
+
+    public static bool HelperMethod_toFrame(object obj, int decimals, out string formattedValue) {
+        if (obj is float floatValue) {
+            formattedValue = GameInfo.ConvertToFrames(floatValue).ToString();
+            return true;
+        }
+        formattedValue = "";
+        return false;
+    }
+
+    public static bool HelperMethod_toPixelPerFrame(object obj, int decimals, out string formattedValue) {
+        if (obj is float floatValue) {
+            formattedValue = GameInfo.ConvertSpeedUnit(floatValue, SpeedUnit.PixelPerFrame).ToString(CultureInfo.InvariantCulture);
+            return true;
+        }
+        if (obj is Vector2 vector2) {
+            formattedValue = GameInfo.ConvertSpeedUnit(vector2, SpeedUnit.PixelPerFrame).ToSimpleString(decimals);
+            return true;
+        }
+        formattedValue = "";
+        return false;
+    }
+
+    public static bool HelperMethod_GetAssembly(object obj, int decimals, out string formattedValue) {
+        // tells you where that weird entity/trigger comes from
+        // not perfect, we expect "CrystallineHelper" but get "vitmod"
+        Type type = obj is Type type2 ? type2 : obj.GetType();
+        formattedValue = type.Assembly.GetName().Name;
+        return true;
+    }
+
+    public static string AutoFormatter(object obj, int decimals) {
+        if (obj is Vector2 vector2) {
+            return vector2.ToSimpleString(decimals);
+        }
+        if (obj is Vector2Double vector2Double) {
+            return vector2Double.ToSimpleString(decimals);
+        }
+        if (obj is float floatValue) {
+            return floatValue.ToFormattedString(decimals);
+        }
+        if (obj is Entity entity) {
+            string id = entity.GetEntityData()?.ToEntityId().ToString() is { } value ? $"[{value}]" : "";
+            return $"{entity.ToString()}{id}";
+        }
+        if (obj is IEnumerable enumerable and not IEnumerable<char>) {
+            bool compressed = enumerable is IEnumerable<Component> or IEnumerable<Entity>;
+            string separator = compressed ? ",\n " : ", ";
+            return IEnumerableToString(enumerable, separator, compressed);
+        }
+        if (obj is Collider collider) {
+            return ColliderToString(collider);
+        }
+
+        return obj.ToString();
+    }
+
     public static string IEnumerableToString(IEnumerable enumerable, string separator, bool compressed) {
         StringBuilder sb = new();
         if (!compressed) {
@@ -386,4 +437,20 @@ public static class InfoCustom {
         return sb.ToString();
     }
 
+    public static string ColliderToString(Collider collider, int iterationHeight = 1) {
+        if (collider is Hitbox hitbox) {
+            return $"Hitbox=[{hitbox.Left},{hitbox.Right}]×[{hitbox.Top},{hitbox.Bottom}]";
+        }
+        if (collider is Circle circle) {
+            if (circle.Position == Vector2.Zero) {
+                return $"Circle=radius {circle.Radius}";
+            } else {
+                return $"Circle=radius {circle.Radius}, offset {circle.Position}";
+            }
+        }
+        if (collider is ColliderList list && iterationHeight > 0) {
+            return "ColliderList: {" + string.Join("; ", list.colliders.Select(s => ColliderToString(s, iterationHeight - 1))) + "}";
+        }
+        return collider.ToString();
+    }
 }

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ The contents of the curly brackets will be converted to actual data, here are so
 - `{Player.Position.Length()}` Invoke method is supported, but must be parameterless and return a non-void type. Be careful not to invoke method that change the game state, as this will cause tas desync.
 - `{Player.AutoJumpTimer.toFrame()}` add `toFrame()` to the end can change the float value to frames.
 - `{Player.Speed.toPixelPerFrame()}` add `toPixelPerFrame()` to the end can change the float/vector2 speed unit to pixel/frame.
-- `{NoDashTrigger.GetModName()}` add `GetModName()` to the end can tell you where this object comes from.
 - `{Player.Position:}` add `:` or `=` to the end will add label before the value. e.g. `{Player.Position:}` is the same as `Player.Position: {Player.Position}`.
 - `AutoJump: {Player.AutoJump} ({Player.AutoJumpTimer.toFrame()})`
 - `Theo: {TheoCrystal.Position}`

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The contents of the curly brackets will be converted to actual data, here are so
 - `{Player.Position.Length()}` Invoke method is supported, but must be parameterless and return a non-void type. Be careful not to invoke method that change the game state, as this will cause tas desync.
 - `{Player.AutoJumpTimer.toFrame()}` add `toFrame()` to the end can change the float value to frames.
 - `{Player.Speed.toPixelPerFrame()}` add `toPixelPerFrame()` to the end can change the float/vector2 speed unit to pixel/frame.
+- `{NoDashTrigger.GetModName()}` add `GetModName()` to the end can tell you where this object comes from.
 - `{Player.Position:}` add `:` or `=` to the end will add label before the value. e.g. `{Player.Position:}` is the same as `Player.Position: {Player.Position}`.
 - `AutoJump: {Player.AutoJump} ({Player.AutoJumpTimer.toFrame()})`
 - `Theo: {TheoCrystal.Position}`


### PR DESCRIPTION
**{Player.toFrame():} will crashes the game**
as after identifying toFrame() as a helperMethod, memberNames become empty, and is never checked. Then calling memberNames.First() will crash the game

bugfix: memberNames empty exception
feat: Add GetAssembly() helperMethod
support Collider in FormatValue
rewrite FormatValue to make it more extensible