### PR TITLE
Replace GetCallingAssembly to be more robust to inlining

### DIFF
--- a/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/TasCommandAttribute.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/TasCommandAttribute.cs
@@ -39,7 +39,7 @@ public class TasCommandAttribute : Attribute {
     [Initialize]
     private static void CollectMethods() {
         MethodInfos.Clear();
-        IEnumerable<MethodInfo> methodInfos = Assembly.GetCallingAssembly().GetTypesSafe().SelectMany(type => type
+        IEnumerable<MethodInfo> methodInfos = typeof(TasCommandAttribute).Assembly.GetTypesSafe().SelectMany(type => type
                 .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
             .Where(info => info.GetCustomAttributes<TasCommandAttribute>().IsNotEmpty());
         foreach (MethodInfo methodInfo in methodInfos) {

--- a/CelesteTAS-EverestInterop/Source/Utils/AttributeUtils.cs
+++ b/CelesteTAS-EverestInterop/Source/Utils/AttributeUtils.cs
@@ -11,7 +11,7 @@ internal static class AttributeUtils {
     private static readonly IDictionary<Type, IEnumerable<MethodInfo>> MethodInfos = new Dictionary<Type, IEnumerable<MethodInfo>>();
 
     public static void CollectMethods<T>() where T : Attribute {
-        MethodInfos[typeof(T)] = Assembly.GetCallingAssembly().GetTypesSafe().SelectMany(type => type
+        MethodInfos[typeof(T)] = typeof(AttributeUtils).Assembly.GetTypesSafe().SelectMany(type => type
             .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
             .Where(info => info.GetParameters().Length == 0 && info.GetCustomAttribute<T>() != null));
     }


### PR DESCRIPTION
AttributeUtils and TasCommandAttribute use GetCallingAssembly to access the CelesteTAS assembly. However, this can fail due to inlining (which it does on Everest Core). This PR replaces that call with a robust way of accessing the assembly.