### PR TITLE
EntityId related enhancements on SetCommand, InvokeCommand, and EvalLua commands

### DIFF
--- a/CelesteTAS-EverestInterop/Source/EverestInterop/InfoHUD/InfoCustom.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/InfoHUD/InfoCustom.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using Celeste;
@@ -40,7 +41,7 @@ public static class InfoCustom {
                 string modName = ConsoleEnhancements.GetModName(type);
                 AllTypes[$"{fullName}@{assemblyName}"] = type;
                 AllTypes[$"{fullName}@{modName}"] = type;
-
+                
                 if (!fullName.StartsWith("Celeste.Mod.Everest+Events")) {
                     AllTypes[$"{fullName.Replace("+", ".")}@{assemblyName}"] = type;
                     AllTypes[$"{fullName.Replace("+", ".")}@{modName}"] = type;
@@ -219,6 +220,10 @@ public static class InfoCustom {
         return TryParseTypes(text, out types, out _, out _);
     }
 
+    public static bool TryParseTypes(string text, out List<Type> types, out string id) {
+        return TryParseTypes(text, out types, out id, out _);
+    }
+
     public static bool TryParseTypes(string text, out List<Type> types, out string entityId, out string errorMessage) {
         types = new List<Type>();
         entityId = "";
@@ -246,7 +251,8 @@ public static class InfoCustom {
                 matchTypeNames = AllTypes.Keys.Where(name => name.Contains($"+{typeName}")).ToList();
             }
 
-            types = matchTypeNames.Select(name => AllTypes[name]).ToList();
+            // one type can correspond to two keys (..@assemblyName and ..@modName), so we need Distinct<Type>()
+            types = matchTypeNames.Select(name => AllTypes[name]).Distinct<Type>().ToList();
             CachedParsedTypes[typeNameWithAssembly] = types;
         }
 

--- a/CelesteTAS-EverestInterop/Source/EverestInterop/Lua/LuaHelpers.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/Lua/LuaHelpers.cs
@@ -10,37 +10,33 @@ using TAS.Utils;
 namespace TAS.EverestInterop.Lua;
 
 public static class LuaHelpers {
-    public static Entity GetEntity(string typeName) {
-        if (TryGetEntityType(typeName, out Type type)) {
-            if (Engine.Scene.Tracker.Entities.TryGetValue(type, out var entities)) {
-                return entities.FirstOrDefault();
-            } else {
-                return Engine.Scene.FirstOrDefault(entity => entity.GetType().IsSameOrSubclassOf(type));
-            }
+
+    // can omit entityId
+    public static Entity GetEntity(string typeNameWithId) {
+        if (TryGetEntityTypeWithId(typeNameWithId, out Type type, out string entityId)) {
+            return InfoCustom.FindEntities(type, entityId).FirstOrDefault();
         } else {
             return null;
         }
     }
-
-    public static List<Entity> GetEntities(string typeName) {
-        if (TryGetEntityType(typeName, out Type type)) {
-            if (Engine.Scene.Tracker.Entities.TryGetValue(type, out var entities)) {
-                return entities;
-            } else {
-                return Engine.Scene.Where(entity => entity.GetType().IsSameOrSubclassOf(type)).ToList();
-            }
+    public static List<Entity> GetEntities(string typeNameWithId) {
+        if (TryGetEntityTypeWithId(typeNameWithId, out Type type, out string entityId)) {
+            return InfoCustom.FindEntities(type, entityId);
         } else {
             return new List<Entity>();
         }
     }
 
     // entityTypeName can be "Player" or "Celeste.Player"
-    private static bool TryGetEntityType(string entityTypeName, out Type type) {
-        if (InfoCustom.TryParseTypes(entityTypeName, out List<Type> types)) {
+
+    private static bool TryGetEntityTypeWithId(string entityTypeName, out Type type, out string entityId) {
+        if (InfoCustom.TryParseTypes(entityTypeName, out List<Type> types, out string id)) {
             type = types.FirstOrDefault(t => t.IsSameOrSubclassOf(typeof(Entity)));
+            entityId = id;
             return type != null;
         } else {
             type = null;
+            entityId = "";
             return false;
         }
     }

--- a/CelesteTAS-EverestInterop/Source/EverestInterop/Lua/env.lua
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/Lua/env.lua
@@ -10,6 +10,7 @@ local function log(message, tag)
 end
 
 --- getEntity("Player") or getEntity("Celeste.Player")
+--- can specify entityId, like getEntity("DustStaticSpinner[s1:12]")
 local function getEntity(entityTypeName)
     return LuaHelpers.GetEntity(entityTypeName)
 end


### PR DESCRIPTION
feat:
1) let EvalLua getEntity command supports entityId
2) make SetCommand and InvokeCommand log warns as few as possible
e.g. "Set CustomSpinner[s1:12].X 0", it should not warn when a FrostHelper spinner[s1:12] exists but cannot find a VivHelper spinner[s1:12]
e.g. "Set CustomSpinner.X 0", it should not warn when FrostHelper spinner exists but VivHelper spinner doesn't exist