### PR TITLE
Added Extended Variants support for `Set` commands

### DIFF
--- a/CelesteTAS-EverestInterop/Source/Utils/ExtendedVariantsUtils.cs
+++ b/CelesteTAS-EverestInterop/Source/Utils/ExtendedVariantsUtils.cs
@@ -7,9 +7,14 @@ namespace TAS.Utils;
 internal static class ExtendedVariantsUtils {
     private static readonly Lazy<EverestModule> module = new(() => ModUtils.GetModule("ExtendedVariantMode"));
     private static readonly Lazy<object> triggerManager = new(() => module.Value?.GetFieldValue<object>("TriggerManager"));
+    private static readonly Lazy<object> variantHandlers = new(() => module.Value?.GetFieldValue<object>("VariantHandlers"));
 
     private static readonly Lazy<FastReflectionDelegate> getCurrentVariantValue = new(() =>
         triggerManager.Value?.GetType().GetMethodInfo("GetCurrentVariantValue")?.GetFastDelegate());
+    private static readonly Lazy<FastReflectionDelegate> setVariantValue = new(() =>
+        module.Value?.GetType().Assembly.GetType("ExtendedVariants.UI.ModOptionsEntries").GetMethodInfo("SetVariantValue")?.GetFastDelegate());
+    private static readonly Lazy<FastReflectionDelegate> dictionareGetItem = new(() =>
+        variantHandlers.Value?.GetType().GetMethodInfo("get_Item")?.GetFastDelegate());
 
     private static readonly Lazy<Type> variantType =
         new(() => module.Value?.GetType().Assembly.GetType("ExtendedVariants.Module.ExtendedVariantsModule+Variant"));
@@ -18,7 +23,7 @@ internal static class ExtendedVariantsUtils {
     private static readonly Lazy<object> upsideDownVariant = new(ParseVariant("UpsideDown"));
     private static readonly Lazy<object> superDashingVariant = new(ParseVariant("SuperDashing"));
 
-    private static Func<object> ParseVariant(string value) {
+    public static Func<object> ParseVariant(string value) {
         return () => {
             try {
                 return variantType.Value == null ? null : Enum.Parse(variantType.Value, value);
@@ -29,10 +34,20 @@ internal static class ExtendedVariantsUtils {
         };
     }
 
-    public static bool UpsideDown => GetCurrentVariantValue(upsideDownVariant);
-    public static bool SuperDashing => GetCurrentVariantValue(superDashingVariant);
+    public static bool UpsideDown => GetCurrentVariantValue(upsideDownVariant) is { } value && (bool)value == true;
+    public static bool SuperDashing => GetCurrentVariantValue(superDashingVariant) is { } value && (bool)value == true;
 
-    private static bool GetCurrentVariantValue(Lazy<object> variant) {
-        return variant.Value is { } value && (bool?) getCurrentVariantValue.Value?.Invoke(triggerManager.Value, value) == true;
+    public static Type? GetVariantType(Lazy<object> variant) {
+        if (variant.Value is null) return null;
+        object handler = dictionareGetItem.Value?.Invoke(variantHandlers.Value, variant.Value);
+        return (Type?)handler?.GetType()?.GetMethodInfo("GetVariantType")?.Invoke(handler, new object[] { });
+    }
+    public static object? GetCurrentVariantValue(Lazy<object> variant) {
+        if (variant.Value is null) return null;
+        return getCurrentVariantValue.Value?.Invoke(triggerManager.Value, variant.Value);
+    }
+    public static void SetVariantValue(Lazy<object> variant, object value) {
+        if (variant.Value is null) return;
+        setVariantValue.Value?.Invoke(null, variant.Value, value);
     }
 }


### PR DESCRIPTION
Adds a special case to properly handle extended variants if the member isnt found in the settings.

Also btw, whats the reason for no longer referencing extvars directly but rather through reflection?