### PR TITLE
Added midway chapter/file times

### DIFF
--- a/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/MetadataCommands.cs
+++ b/CelesteTAS-EverestInterop/Source/TAS/Input/Commands/MetadataCommands.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Celeste;
 using Celeste.Mod;
+using Monocle;
 using TAS.Communication;
 using TAS.Module;
 using TAS.Utils;
@@ -67,12 +68,31 @@ public static class MetadataCommands {
         // dummy
     }
 
+    [TasCommand("MidwayFileTime", AliasNames = new[] {"MidwayFileTime:", "MidwayFileTime："}, CalcChecksum = false)]
+    private static void MidwayFileTimeCommand() {
+        if (TasStartFileTime != null && SaveData.Instance != null) {
+            UpdateAllMetadata("MidwayFileTime", 
+                _ => GameInfo.FormatTime(SaveData.Instance.Time - TasStartFileTime.Value), 
+                command => Manager.Controller.CurrentCommands.Contains(command));
+        }
+    }
+
+    [TasCommand("MidwayChapterTime", AliasNames = new[] {"MidwayChapterTime:", "MidwayChapterTime："}, CalcChecksum = false)]
+    private static void MidwayChapterTimeCommand() {
+        if (!Manager.Running || Engine.Scene is not Level level || !level.Session.StartedFromBeginning) {
+            return;
+        }
+        UpdateAllMetadata("MidwayChapterTime", 
+            _ => GameInfo.GetChapterTime(level), 
+            command => Manager.Controller.CurrentCommands.Contains(command));
+    }
+
     private static void UpdateChapterTime(Level level) {
         if (!Manager.Running || !level.Session.StartedFromBeginning) {
             return;
         }
 
-        UpdateAllMetadata("ChapterTime", command => GameInfo.GetChapterTime(level));
+        UpdateAllMetadata("ChapterTime", _ => GameInfo.GetChapterTime(level));
     }
 
     public static void UpdateRecordCount(InputController inputController) {

--- a/Docs/Commands.md
+++ b/Docs/Commands.md
@@ -308,6 +308,11 @@ NOTE: These commands require [TAS Recorder](https://gamebanana.com/tools/14085)!
 - e.g. `ChapterTime: 0:49.334(2902)`
 - After completing the whole level from the beginning, auto updating the chapter time.
 
+### MidwayFileTime / MidwayChapterTime
+- e.g. `MidwayFileTime: 1:04.107(3771)`
+- e.g. `MidwayChapterTime: 1:41.677(5981)`
+- Same as `FileTime`/`ChapterTime`, except it updates when the command is executed. 
+
 ### AnalogueMode
 - `AnalogueMode, (Mode)`
 - `AnalogMode, (Mode)` also works


### PR DESCRIPTION
Adds a `ChapterTime`/`FileTime` command, but for midway into the file.
For example: 6AC has two important chapter times: cassette collect and chapter finished.
They are called `MidwayChapterTime` and `MidwayFileTime`, which get updated when the command is executed, instead of at chapter completion/TAS ending.
The commands still have to be added to Studio, but thats probably easier for you (partially because the list goes offscreen for me lol).

NOTE: The prefix `Midway` was just the first thing which came to mind. Im sure theres something which just.. sounds a bit better?