### PR TITLE
Remove some log of InfoWatchEntity

### DIFF
--- a/CelesteTAS-EverestInterop/Source/EverestInterop/InfoHUD/InfoWatchEntity.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/InfoHUD/InfoWatchEntity.cs
@@ -216,7 +216,7 @@ public static class InfoWatchEntity {
     }
 
     private static void PrintAllSimpleValues(Entity entity) {
-        ("Info of Clicked Entity:\n" + GetEntityValues(entity, WatchEntityType.All)).Log(true);
+        ("Info of Clicked Entity:\n" + GetEntityValues(entity, WatchEntityType.All)).Log(false);
     }
 
     private static string GetEntityValues(Entity entity, WatchEntityType watchEntityType, string separator = "\n", int decimals = 2) {


### PR DESCRIPTION
make InfoWatchEntity no longer log to the in-game command console (but still log to Everest's Logger)

some reasons to do this:
1. we already have infoHUD and Everest's log console window
2. Due to the limit of the in-game command console, you can actually only read up to last 30 lines of the InfoWatchEntity logs (which is not even enough for a spring), making this function even more useless