### PR TITLE
Simplified Graphics Hide Brokemia.PixelRendered.Vineinator

### DIFF
--- a/CelesteTAS-EverestInterop/Source/EverestInterop/SimplifiedGraphicsFeature.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/SimplifiedGraphicsFeature.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -202,10 +202,15 @@ public static class SimplifiedGraphicsFeature {
             ModUtils.GetType("ContortHelper", "ContortHelper.BetterLightningStrike")
         );
 
+
         HookHelper.SkipMethod(t, nameof(IsSimplifiedClutteredEntity), "Render",
             typeof(ReflectionTentacles), typeof(SummitCloud), typeof(TempleEye), typeof(Wire),
             typeof(Cobweb), typeof(HangingLamp),
-            typeof(DustGraphic).GetNestedType("Eyeballs", BindingFlags.NonPublic)
+            typeof(DustGraphic).GetNestedType("Eyeballs", BindingFlags.NonPublic),
+            ModUtils.GetType("BrokemiaHelper", "BrokemiaHelper.PixelRendered.PixelComponent")
+        );
+        HookHelper.SkipMethod(t, nameof(IsSimplifiedClutteredEntity), "DebugRender",
+            ModUtils.GetType("BrokemiaHelper", "BrokemiaHelper.PixelRendered.PixelComponent")
         );
         On.Celeste.FloatingDebris.ctor_Vector2 += FloatingDebris_ctor;
         On.Celeste.MoonCreature.ctor_Vector2 += MoonCreature_ctor;


### PR DESCRIPTION
Before:
![celeste](https://github.com/EverestAPI/CelesteTAS-EverestInterop/assets/68326284/83cf12eb-805e-4731-878e-1e133e50549c)

After:
![celeste2](https://github.com/EverestAPI/CelesteTAS-EverestInterop/assets/68326284/36728a88-bf09-42c6-9008-82433b4c5601)

`Brokemia.PixelRendered.Vineinator` is rendered by its component `PixelComponent,` so we need to skip `PixelComponent.Render` to hide vines
`PixelComponent.DebugRender` shows in which chunks there are textures (chunks are shown as dark green squares). It is also redundant for TASers

In `BrokemiaHelper`, only `Vineinator` and `RWLizard` uses `PixelComponent`. I find that `RWLizard` actually does not have textures, and there's no Ahorn/Loenn scripts for it, so I assume `RWLizard` is actually abandoned.
In this case, hooking `PixelComponent` will only affect `Vineinator` (assume no other mods use `PixelComponent`), so that's what we want.
