### PR TITLE
Fix AuraHelper desync

### DIFF
--- a/CelesteTAS-EverestInterop/Source/EverestInterop/DesyncFixer.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/DesyncFixer.cs
@@ -237,7 +237,7 @@ public static class DesyncFixer {
         return binding.Pressed ? count : 0;
     }
 
-    private static Random AuraHelperSharedRandom = new Random(1234); // this random needs to be used all through aura entity's lifetime
+    internal static Random AuraHelperSharedRandom = new Random(1234); // this random needs to be used all through aura entity's lifetime
 
     private static void SetupAuraHelperRandom(ILContext il) {
         ILCursor cursor = new ILCursor(il);

--- a/CelesteTAS-EverestInterop/Source/EverestInterop/DesyncFixer.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/DesyncFixer.cs
@@ -18,6 +18,9 @@ public static class DesyncFixer {
     private const string pushedRandomFlag = "CelesteTAS_PushedRandom";
     private static int debrisAmount;
 
+    // this random needs to be used all through aura entity's lifetime
+    internal static Random AuraHelperSharedRandom = new Random(1234);
+
     [Initialize]
     private static void Initialize() {
         Dictionary<MethodInfo, int> methods = new() {
@@ -237,8 +240,6 @@ public static class DesyncFixer {
         return binding.Pressed ? count : 0;
     }
 
-    internal static Random AuraHelperSharedRandom = new Random(1234); // this random needs to be used all through aura entity's lifetime
-
     private static void SetupAuraHelperRandom(ILContext il) {
         ILCursor cursor = new ILCursor(il);
         cursor.Emit(OpCodes.Ldarg_1);
@@ -248,7 +249,7 @@ public static class DesyncFixer {
     private static void CreateAuraHelperRandom(Vector2 vector2) {
         if (Manager.Running) {
             int seed = vector2.GetHashCode();
-            if (Engine.Scene is Level level) {
+            if (Engine.Scene.GetLevel() is { } level) {
                 seed += level.Session.LevelData.LoadSeed;
             }
             AuraHelperSharedRandom = new Random(seed);

--- a/CelesteTAS-EverestInterop/Source/EverestInterop/DesyncFixer.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/DesyncFixer.cs
@@ -56,6 +56,12 @@ public static class DesyncFixer {
         if (ModUtils.GetType("EmoteMod", "Celeste.Mod.EmoteMod.EmoteWheelModule") is { } emoteModuleType) {
             emoteModuleType.GetMethodInfo("Player_Update")?.IlHook(PreventEmoteMod);
         }
+
+        if (ModUtils.GetType("AuraHelper", "AuraHelper.Lantern") is { } auraLanternType) {
+            auraLanternType.GetConstructor(new Type[] { typeof(Vector2), typeof(string), typeof(int) })?.IlHook(SetupAuraHelperRandom);
+            auraLanternType.GetMethod("Update")?.IlHook(FixAuraEntityDesync);
+            ModUtils.GetType("AuraHelper", "AuraHelper.Generator")?.GetMethod("Update")?.IlHook(FixAuraEntityDesync);
+        }
     }
 
     [Load]
@@ -229,5 +235,44 @@ public static class DesyncFixer {
 
     private static int IsEmoteWheelBindingPressed(ButtonBinding binding, int count) {
         return binding.Pressed ? count : 0;
+    }
+
+    private static Random AuraHelperSharedRandom = new Random(1234); // this random needs to be used all through aura entity's lifetime
+
+    private static void SetupAuraHelperRandom(ILContext il) {
+        ILCursor cursor = new ILCursor(il);
+        cursor.Emit(OpCodes.Ldarg_1);
+        cursor.EmitDelegate(CreateAuraHelperRandom);
+    }
+
+    private static void CreateAuraHelperRandom(Vector2 vector2) {
+        if (Manager.Running) {
+            int seed = vector2.GetHashCode();
+            if (Engine.Scene is Level level) {
+                seed += level.Session.LevelData.LoadSeed;
+            }
+            AuraHelperSharedRandom = new Random(seed);
+        }
+    }
+
+    private static void FixAuraEntityDesync(ILContext il) {
+        ILCursor cursor = new ILCursor(il);
+        cursor.EmitDelegate(AuraPushRandom);
+        while (cursor.TryGotoNext(MoveType.AfterLabel, i => i.OpCode == OpCodes.Ret)) {
+            cursor.EmitDelegate(AuraPopRandom);
+            cursor.Index++;
+        }
+    }
+
+    private static void AuraPushRandom() {
+        if (Manager.Running) {
+            Calc.PushRandom(AuraHelperSharedRandom);
+        }
+    }
+
+    private static void AuraPopRandom() {
+        if (Manager.Running) {
+            Calc.PopRandom();
+        }
     }
 }

--- a/CelesteTAS-EverestInterop/Source/Utils/SpeedrunToolUtils.cs
+++ b/CelesteTAS-EverestInterop/Source/Utils/SpeedrunToolUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -30,6 +30,7 @@ internal static class SpeedrunToolUtils {
     private static Dictionary<Follower, bool> followers;
     private static Dictionary<int, int> insertedSlots = new();
     private static bool disallowUnsafeInput;
+    private static Random auraRandom;
 
     public static void AddSaveLoadAction() {
         Action<Dictionary<Type, Dictionary<string, object>>, Level> save = (_, _) => {
@@ -48,6 +49,7 @@ internal static class SpeedrunToolUtils {
             followers = HitboxSimplified.Followers.DeepCloneShared();
             insertedSlots = SaveAndQuitReenterCommand.InsertedSlots.DeepCloneShared();
             disallowUnsafeInput = SafeCommand.DisallowUnsafeInput;
+            auraRandom = DesyncFixer.AuraHelperSharedRandom.DeepCloneShared();
         };
         Action<Dictionary<Type, Dictionary<string, object>>, Level> load = (_, _) => {
             EntityDataHelper.CachedEntityData = savedEntityData.DeepCloneShared();
@@ -69,12 +71,14 @@ internal static class SpeedrunToolUtils {
             HitboxSimplified.Followers = followers.DeepCloneShared();
             SaveAndQuitReenterCommand.InsertedSlots = insertedSlots.DeepCloneShared();
             SafeCommand.DisallowUnsafeInput = disallowUnsafeInput;
+            DesyncFixer.AuraHelperSharedRandom = auraRandom.DeepCloneShared();
         };
         Action clear = () => {
             savedEntityData = null;
             pressKeys = null;
             followers = null;
             InfoWatchEntity.SavedRequireWatchEntities.Clear();
+            auraRandom = null;
         };
 
         ConstructorInfo constructor = typeof(SaveLoadAction).GetConstructors()[0];


### PR DESCRIPTION
As shown in the picture, the entity in GalleryCollab heartside has RNG, so this PR aims to fix it
(I've contacted AuraHelper's author and he says he will not udpate AuraHelper recently, so there's no worry that we need to revert this commit shortly after)
![celeste](https://github.com/EverestAPI/CelesteTAS-EverestInterop/assets/68326284/a8b3bd1a-b1a1-4bc7-8896-414e2390b568)

btw maybe this line of code
[`typeof(Entity).GetMethod("Update").HookAfter(AfterEntityUpdate);`](https://github.com/EverestAPI/CelesteTAS-EverestInterop/blob/master/CelesteTAS-EverestInterop/Source/EverestInterop/DesyncFixer.cs#L66)
can be changed to hook on `Scene.AfterUpdate` instead, but this may cause some existing tases to desync