### PR TITLE
Simplified Graphics Hide SinkingPlatform Shaker

### DIFF
--- a/CelesteTAS-EverestInterop/Source/EverestInterop/SimplifiedGraphicsFeature.cs
+++ b/CelesteTAS-EverestInterop/Source/EverestInterop/SimplifiedGraphicsFeature.cs
@@ -212,6 +212,12 @@ public static class SimplifiedGraphicsFeature {
             typeof(DustGraphic).GetNestedType("Eyeballs", BindingFlags.NonPublic),
             ModUtils.GetType("BrokemiaHelper", "BrokemiaHelper.PixelRendered.PixelComponent")
         );
+        typeof(SinkingPlatform).GetMethodInfo("Render").IlHook((cursor, _) => {
+            if (cursor.TryGotoNext(MoveType.After, ins => ins.MatchLdfld<Shaker>(nameof(Shaker.Value)))) {
+                cursor.EmitDelegate(IsSimplifiedClutteredEntity);
+                cursor.EmitDelegate((Vector2 vec, bool b) => b ? Vector2.Zero : vec);
+            }
+        });
         On.Celeste.FloatingDebris.ctor_Vector2 += FloatingDebris_ctor;
         On.Celeste.MoonCreature.ctor_Vector2 += MoonCreature_ctor;
         On.Celeste.ResortLantern.ctor_Vector2 += ResortLantern_ctor;


### PR DESCRIPTION
Sinking Platform has a (purely visual) Shaker, which makes it hard to see the hitbox
there are some other cases where Shaker's are used in vanilla, but they look fine so i don't patch them
 
Before
![celeste](https://github.com/EverestAPI/CelesteTAS-EverestInterop/assets/68326284/0a7dcb3b-07ac-492d-a543-d9afde3ce244)
After
![celeste2](https://github.com/EverestAPI/CelesteTAS-EverestInterop/assets/68326284/3f40190a-2801-4f46-a199-ba83586d6a1a)