### PR TITLE
fix: choose 'Documents/TAS Files' as fallback directory to prevent `new Uri` crash

### DIFF
--- a/Studio/CelesteStudio/Studio.cs
+++ b/Studio/CelesteStudio/Studio.cs
@@ -416,7 +416,7 @@ public sealed class Studio : Form {
 
     private string GetFilePickerDirectory() {
         string fallbackDir = string.IsNullOrWhiteSpace(Settings.Instance.LastSaveDirectory)
-            ? Path.Combine(CelesteDirectory ?? string.Empty, "TAS Files")
+            ? Path.Combine(CelesteDirectory ?? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "TAS Files")
             : Settings.Instance.LastSaveDirectory;
 
         string dir = Editor.Document.FilePath == Document.ScratchFile


### PR DESCRIPTION
`new Uri("TAS Files")` crashes since it cannot figure out the protocol or something.

```
System.UriFormatException: Invalid URI: The format of the URI could not be determined.
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)
   at System.Uri..ctor(String uriString)
   at CelesteStudio.Studio.OnSaveFileAs() in C:\Users\Jakob\Documents\dev\celeste\StudioV3\Studio\CelesteStudio\Studio.cs:line 514
```