### PR TITLE
Add support for running under wine + `netstandard2.1` compat

### DIFF
--- a/StudioCommunication/ActionLine.cs
+++ b/StudioCommunication/ActionLine.cs
@@ -43,7 +43,11 @@ public struct ActionLine() {
         actionLine = default;
         actionLine.CustomBindings = new HashSet<char>();
 
+#if NETCOREAPP
         string[] tokens = line.Trim().Split(Delimiter, StringSplitOptions.TrimEntries);
+#else
+        string[] tokens = line.Trim().Split(Delimiter).Select(token => token.Trim()).ToArray();
+#endif
         if (tokens.Length == 0) return false;
 
         if (string.IsNullOrWhiteSpace(tokens[0]) || int.TryParse(tokens[0], out _)) {
@@ -82,7 +86,7 @@ public struct ActionLine() {
 
             // Parse feather angle/magnitude
             bool validAngle = true;
-            if (action == Actions.Feather && i + 1 < tokens.Length && (validAngle = float.TryParse(tokens[i + 1], CultureInfo.InvariantCulture, out float angle))) {
+            if (action == Actions.Feather && i + 1 < tokens.Length && (validAngle = float.TryParse(tokens[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))) {
                 if (angle > 360.0f)
                     actionLine.FeatherAngle = "360";
                 else if (angle < 0.0f)
@@ -93,9 +97,9 @@ public struct ActionLine() {
 
                 // Allow empty magnitude, so the comma won't get removed
                 bool validMagnitude = true;
-                if (i + 1 < tokens.Length && (string.IsNullOrWhiteSpace(tokens[i + 1]) || (validMagnitude = float.TryParse(tokens[i + 1], CultureInfo.InvariantCulture, out float _)))) {
+                if (i + 1 < tokens.Length && (string.IsNullOrWhiteSpace(tokens[i + 1]) || (validMagnitude = float.TryParse(tokens[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out float _)))) {
                     // Parse again since it might be an empty string
-                    if (float.TryParse(tokens[i + 1], CultureInfo.InvariantCulture, out float magnitude)) {
+                    if (float.TryParse(tokens[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out float magnitude)) {
                         if (magnitude > 1.0f)
                             actionLine.FeatherMagnitude = "1";
                         else if (magnitude < 0.0f)
@@ -110,7 +114,7 @@ public struct ActionLine() {
                 } else if (!validMagnitude && !ignoreInvalidFloats) {
                     return false;
                 }
-            } else if (!validAngle && i + 2 < tokens.Length && string.IsNullOrEmpty(tokens[i + 1]) && (validAngle = float.TryParse(tokens[i + 2], CultureInfo.InvariantCulture, out angle))) {
+            } else if (!validAngle && i + 2 < tokens.Length && string.IsNullOrEmpty(tokens[i + 1]) && (validAngle = float.TryParse(tokens[i + 2], NumberStyles.Float, CultureInfo.InvariantCulture, out angle))) {
                 // Empty angle, treat magnitude as angle
                 if (angle > 360.0f)
                     actionLine.FeatherAngle = "360";
@@ -277,14 +281,14 @@ public struct ActionLine() {
 
         // Clamp angle / magnitude
         if (actionLine.FeatherAngle is { } angleString) {
-            if (float.TryParse(angleString, CultureInfo.InvariantCulture, out float angle)) {
+            if (float.TryParse(angleString, NumberStyles.Float, CultureInfo.InvariantCulture, out float angle)) {
                 actionLine.FeatherAngle = Math.Clamp(angle, 0.0f, 360.0f).ToString(CultureInfo.InvariantCulture);
             } else if (!ignoreInvalidFloats) {
                 return false;
             }
         }
         if (actionLine.FeatherMagnitude is { } magnitudeString) {
-            if (float.TryParse(magnitudeString, CultureInfo.InvariantCulture, out float magnitude)) {
+            if (float.TryParse(magnitudeString, NumberStyles.Float, CultureInfo.InvariantCulture, out float magnitude)) {
                 actionLine.FeatherMagnitude = Math.Clamp(magnitude, 0.0f, 1.0f).ToString(CultureInfo.InvariantCulture);
             } else if (!ignoreInvalidFloats) {
                 return false;

--- a/StudioCommunication/ActionLine.cs
+++ b/StudioCommunication/ActionLine.cs
@@ -43,7 +43,7 @@ public struct ActionLine() {
         actionLine = default;
         actionLine.CustomBindings = new HashSet<char>();
 
-#if NETCOREAPP
+#if NET5_0_OR_GREATER
         string[] tokens = line.Trim().Split(Delimiter, StringSplitOptions.TrimEntries);
 #else
         string[] tokens = line.Trim().Split(Delimiter).Select(token => token.Trim()).ToArray();

--- a/StudioCommunication/CommunicationAdapterBase.cs
+++ b/StudioCommunication/CommunicationAdapterBase.cs
@@ -67,6 +67,8 @@ public abstract class CommunicationAdapterBase : IDisposable {
     // Safety caps to avoid any crashes
     private const int MaxOffset = BufferCapacity - 4096;
     private const byte MaxMessageCount = 100;
+    
+    private static bool IsWine() => Environment.GetEnvironmentVariable("WINEPREFIX") != null;
 
     private const string MutexName = "Global\\CelesteTAS_StudioCom";
 
@@ -92,15 +94,22 @@ public abstract class CommunicationAdapterBase : IDisposable {
             mutex = new Mutex(initiallyOwned: true, MutexName, out _);
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+        bool isWine = IsWine();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !isWine) {
             writeFile = MemoryMappedFile.CreateOrOpen(writeName, BufferCapacity);
             readFile = MemoryMappedFile.CreateOrOpen(readName, BufferCapacity);
         } else {
-            var writePath = Path.Combine(Path.GetTempPath(), $"{writeName}.share");
-            var readPath  = Path.Combine(Path.GetTempPath(), $"{readName}.share");
+            var tempPath = isWine ? "/tmp" : Path.GetTempPath();
+            var writePath = Path.Combine(tempPath, $"{writeName}.share");
+            var readPath = Path.Combine(tempPath, $"{readName}.share");
 
-            using var writeFs = File.Open(writePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+            using var writeFs = File.Open(writePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
             using var readFs = File.Open(readPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+            writeFs.Seek(BufferCapacity - 1, SeekOrigin.Begin);
+            writeFs.WriteByte(0);
+            readFs.Seek(BufferCapacity - 1, SeekOrigin.Begin);
+            readFs.WriteByte(0);
 
             writeFile = MemoryMappedFile.CreateFromFile(writeFs, null, BufferCapacity, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, leaveOpen: false);
             readFile = MemoryMappedFile.CreateFromFile(readFs, null, BufferCapacity, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, leaveOpen: false);

--- a/StudioCommunication/NetStandardPolyfill.cs
+++ b/StudioCommunication/NetStandardPolyfill.cs
@@ -1,0 +1,45 @@
+﻿#if !NETCOREAPP
+using System;
+using System.IO;
+
+namespace System.Runtime.CompilerServices {
+    class IsExternalInit { }
+}
+
+namespace StudioCommunication {
+    public static class NetStandardPolyfill {
+        // https://github.com/microsoft/referencesource/blob/51cf7850defa8a17d815b4700b67116e3fa283c2/mscorlib/system/io/binarywriter.cs#L414
+        public static void Write7BitEncodedInt(this BinaryWriter writer, int value) {
+            // Write out an int 7 bits at a time.  The high bit of the byte,
+            // when on, tells reader to continue reading more bytes.
+            uint v = (uint) value;   // support negative numbers
+            while (v >= 0x80) {
+                writer.Write((byte) (v | 0x80));
+                v >>= 7;
+            }
+            writer.Write((byte)v);
+        }
+        
+        // https://github.com/microsoft/referencesource/blob/51cf7850defa8a17d815b4700b67116e3fa283c2/mscorlib/system/io/binaryreader.cs#L582
+        public static int Read7BitEncodedInt(this BinaryReader writer) {
+            // Read out an Int32 7 bits at a time.  The high bit
+            // of the byte when on means to continue reading more bytes.
+            int count = 0;
+            int shift = 0;
+            byte b;
+            do {
+                // Check for a corrupted stream.  Read a max of 5 bytes.
+                // In a future version, add a DataFormatException.
+                if (shift == 5 * 7)  // 5 bytes max per Int32, shift += 7
+                    throw new FormatException("Format_Bad7BitInt32");
+
+                // ReadByte handles end of stream cases for us.
+                b = writer.ReadByte();
+                count |= (b & 0x7F) << shift;
+                shift += 7;
+            } while ((b & 0x80) != 0);
+            return count;
+        }
+    }
+}
+#endif

--- a/StudioCommunication/NetStandardPolyfill.cs
+++ b/StudioCommunication/NetStandardPolyfill.cs
@@ -1,10 +1,6 @@
-﻿#if !NETCOREAPP
+﻿#if !NET7_0_OR_GREATER
 using System;
 using System.IO;
-
-namespace System.Runtime.CompilerServices {
-    class IsExternalInit { }
-}
 
 namespace StudioCommunication {
     public static class NetStandardPolyfill {
@@ -41,5 +37,11 @@ namespace StudioCommunication {
             return count;
         }
     }
+}
+#endif
+
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices {
+    class IsExternalInit { }
 }
 #endif

--- a/StudioCommunication/StudioCommunication.csproj
+++ b/StudioCommunication/StudioCommunication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/StudioCommunication/Util/BinaryHelper.cs
+++ b/StudioCommunication/Util/BinaryHelper.cs
@@ -54,14 +54,16 @@ public static class BinaryHelper {
             case short v:
                 writer.Write(v);
                 return;
+            #if NETCOREAPP
             case Half v:
                 writer.Write(v);
                 return;
+            #endif
             case string v:
                 writer.Write(v);
                 return;
 
-            case IEnumerable v when v.GetType().IsArray || v.GetType().IsAssignableTo(typeof(IList)):
+            case IEnumerable v when v.GetType().IsArray || v is IList:
                 var values = v.Cast<object>().ToArray();
                 writer.Write7BitEncodedInt(values.Length);
                 for (int i = 0; i < values.Length; i++) {
@@ -113,8 +115,10 @@ public static class BinaryHelper {
             return reader.ReadSByte();
         if (type == typeof(short))
             return reader.ReadInt16();
+        #if NETCOREAPP
         if (type == typeof(Half))
             return reader.ReadHalf();
+        #endif
         if (type == typeof(string))
             return reader.ReadString();
 
@@ -129,7 +133,7 @@ public static class BinaryHelper {
 
             return values;
         }
-        if (type.IsAssignableTo(typeof(IList)) && type.IsGenericType) {
+        if (typeof(IList).IsAssignableFrom(type) && type.IsGenericType) {
             int count = reader.Read7BitEncodedInt();
             var elemType = type.GetElementType() ?? type.GenericTypeArguments[0];
 
@@ -140,7 +144,7 @@ public static class BinaryHelper {
 
             return list;
         }
-        if (type.IsAssignableTo(typeof(ITuple)) && type.IsGenericType) {
+        if (typeof(ITuple).IsAssignableFrom(type) && type.IsGenericType) {
             int count = reader.Read7BitEncodedInt();
 
             var values = new object?[count];

--- a/StudioCommunication/Util/BinaryHelper.cs
+++ b/StudioCommunication/Util/BinaryHelper.cs
@@ -54,7 +54,7 @@ public static class BinaryHelper {
             case short v:
                 writer.Write(v);
                 return;
-            #if NETCOREAPP
+            #if NET5_0_OR_GREATER
             case Half v:
                 writer.Write(v);
                 return;
@@ -115,7 +115,7 @@ public static class BinaryHelper {
             return reader.ReadSByte();
         if (type == typeof(short))
             return reader.ReadInt16();
-        #if NETCOREAPP
+        #if NET5_0_OR_GREATER
         if (type == typeof(Half))
             return reader.ReadHalf();
         #endif

--- a/StudioCommunication/Util/CommonExtensions.cs
+++ b/StudioCommunication/Util/CommonExtensions.cs
@@ -46,7 +46,7 @@ public ref struct LineIterator(ReadOnlySpan<char> text) {
 }
 
 public static class NumberExtensions {
-    public static T Mod<T>(this T x, T m) where T : INumber<T> => (x % m + m) % m;
+    public static int Mod(this int x, int m) => (x % m + m) % m;
 }
 
 public static class StringExtensions {
@@ -67,26 +67,25 @@ public static class StringExtensions {
     }
 
     private static readonly string[] sizeSuffixes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
-    public static (string Amount, string Suffix) HumanReadableBytes<T>(this T value, int decimals = 1) where T : INumber<T>
+    public static (string Amount, string Suffix) HumanReadableBytes(this long value, int decimals = 1)
     {
-        if (value < T.Zero) {
+        if (value < 0) {
             (string amount, string suffix) = HumanReadableBytes(-value, decimals);
             return ("-" + amount, suffix);
         }
-        if (value == T.Zero) {
+        if (value == 0) {
             return (string.Format($"{{0:n{decimals}}}", 0), sizeSuffixes[0]);
         }
 
         // mag is 0 for bytes, 1 for KiB, 2, for MiB, etc.
-        int mag = (int)Math.Log(double.CreateChecked(value), 1024);
+        int mag = (int)Math.Log(value, 1024);
 
         // 1L << (mag * 10) == 2 ^ (10 * mag)
         // (i.e. the number of bytes in the unit corresponding to mag)
-        decimal adjustedSize = decimal.CreateChecked(value) / (1L << (mag * 10));
+        decimal adjustedSize = (decimal)value / (1L << (mag * 10));
 
         // Make adjustment when the value is large enough that it would round up to 1000 or more
-        if (Math.Round(adjustedSize, decimals) >= 1000)
-        {
+        if (Math.Round(adjustedSize, decimals) >= 1000) {
             mag += 1;
             adjustedSize /= 1024;
         }

--- a/StudioCommunication/Util/CommonExtensions.cs
+++ b/StudioCommunication/Util/CommonExtensions.cs
@@ -45,9 +45,11 @@ public ref struct LineIterator(ReadOnlySpan<char> text) {
     }
 }
 
+#if NETCOREAPP
 public static class NumberExtensions {
-    public static int Mod(this int x, int m) => (x % m + m) % m;
+    public static T Mod<T>(this T x, T m) where T : INumber<T> => (x % m + m) % m;
 }
+#endif
 
 public static class StringExtensions {
     private static readonly string format = "0.".PadRight(339, '#');
@@ -66,32 +68,35 @@ public static class StringExtensions {
         }
     }
 
+#if NETCOREAPP
     private static readonly string[] sizeSuffixes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
-    public static (string Amount, string Suffix) HumanReadableBytes(this long value, int decimals = 1)
+    public static (string Amount, string Suffix) HumanReadableBytes<T>(this T value, int decimals = 1) where T : INumber<T>
     {
-        if (value < 0) {
+        if (value < T.Zero) {
             (string amount, string suffix) = HumanReadableBytes(-value, decimals);
             return ("-" + amount, suffix);
         }
-        if (value == 0) {
+        if (value == T.Zero) {
             return (string.Format($"{{0:n{decimals}}}", 0), sizeSuffixes[0]);
         }
 
         // mag is 0 for bytes, 1 for KiB, 2, for MiB, etc.
-        int mag = (int)Math.Log(value, 1024);
+        int mag = (int)Math.Log(double.CreateChecked(value), 1024);
 
         // 1L << (mag * 10) == 2 ^ (10 * mag)
         // (i.e. the number of bytes in the unit corresponding to mag)
-        decimal adjustedSize = (decimal)value / (1L << (mag * 10));
+        decimal adjustedSize = decimal.CreateChecked(value) / (1L << (mag * 10));
 
         // Make adjustment when the value is large enough that it would round up to 1000 or more
-        if (Math.Round(adjustedSize, decimals) >= 1000) {
+        if (Math.Round(adjustedSize, decimals) >= 1000)
+        {
             mag += 1;
             adjustedSize /= 1024;
         }
 
         return (string.Format($"{{0:n{decimals}}}", adjustedSize), sizeSuffixes[mag]);
     }
+#endif
 
     /// Replaces the specified range inside the string and returns the result
     public static string ReplaceRange(this string self, int startIndex, int count, string replacement) {

--- a/StudioCommunication/Util/CommonExtensions.cs
+++ b/StudioCommunication/Util/CommonExtensions.cs
@@ -45,7 +45,7 @@ public ref struct LineIterator(ReadOnlySpan<char> text) {
     }
 }
 
-#if NETCOREAPP
+#if NET7_0_OR_GREATER
 public static class NumberExtensions {
     public static T Mod<T>(this T x, T m) where T : INumber<T> => (x % m + m) % m;
 }
@@ -68,7 +68,7 @@ public static class StringExtensions {
         }
     }
 
-#if NETCOREAPP
+#if NET7_0_OR_GREATER
     private static readonly string[] sizeSuffixes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
     public static (string Amount, string Suffix) HumanReadableBytes<T>(this T value, int decimals = 1) where T : INumber<T>
     {

--- a/StudioCommunication/Util/EnumArray.cs
+++ b/StudioCommunication/Util/EnumArray.cs
@@ -7,7 +7,7 @@ public readonly struct EnumDictionary<TEnum, TValue> where TEnum : struct, Enum 
     private readonly TValue[] data;
     
     public EnumDictionary() {
-        var values = Enum.GetValuesAsUnderlyingType<TEnum>();
+        var values = Enum.GetValues(typeof(TEnum));
         
         long maxIdx = 0;
         foreach (var value in values) {

--- a/StudioCommunication/Util/ProcessHelper.cs
+++ b/StudioCommunication/Util/ProcessHelper.cs
@@ -10,9 +10,9 @@ public static class ProcessHelper
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             return Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-            return Process.Start("xdg-open", [path]);
+            return Process.Start("xdg-open", path);
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-            return Process.Start("open", [path]);
+            return Process.Start("open", path);
         } else {
             throw new NotImplementedException($"Unsupported platform: {RuntimeInformation.OSDescription} with {RuntimeInformation.OSArchitecture}");
         }
@@ -22,7 +22,7 @@ public static class ProcessHelper
     public static void Terminate(this Process process) {
         // Unix
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-            Process.Start("kill", ["-s", "SIGINT", process.Id.ToString()]);
+            Process.Start("kill", $"-s SIGINT ${process.Id.ToString()}");
             return;
         }
 


### PR DESCRIPTION
I'm trying to make studio interface work with another game, and for that I need
- `netstandard2.1` compatibility. This is mostly a few polyfill or slight method tweaks
- The game is running in wine, which doesn't have named mutexes, and I want to run studio outside wine anyways, so
  - when running in wine use /tmp/ paths
  - fix the following exception by ensure the file is large enough (https://stackoverflow.com/a/12251630)

```
[Info] Studio Communication @ Studio: Starting communication...
System.ArgumentOutOfRangeException: The capacity may not be smaller than the file size. (Parameter 'capacity')
   at System.IO.MemoryMappedFiles.MemoryMappedFile.VerifyMemoryMappedFileAccess(MemoryMappedFileAccess access, Int64 capacity, SafeFileHandle fileHandle, Int64 fileSize, Boolean& isRegularFile)
   at System.IO.MemoryMappedFiles.MemoryMappedFile.CreateCore(SafeFileHandle fileHandle, String mapName, HandleInheritability inheritability, MemoryMappedFileAccess access, MemoryMappedFileOptions options, Int64 capacity, Int64 fileSize)
   at System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(FileStream fileStream, String mapName, Int64 capacity, MemoryMappedFileAccess access, HandleInheritability inheritability, Boolean leaveOpen)
   at StudioCommunication.CommunicationAdapterBase..ctor(Location location) in /home/jakob/dev/celeste/celestetas/StudioCommunication/CommunicationAdapterBase.cs:line 106
   at CelesteStudio.Communication.CommunicationAdapterStudio..ctor(Action connectionChanged, Action`1 stateChanged, Action`1 linesChanged, Action`1 bindingsChanged, Action`1 settingsChanged, Action`1 commandsChanged, Action`3 commandAutoCompleteResponse) in /home/jakob/dev/celeste/celestetas/Studio/CelesteStudio/Communication/CommunicationAdapterStudio.cs:line 21
   at CelesteStudio.Communication.CommunicationWrapper.Start() in /home/jakob/dev/celeste/celestetas/Studio/CelesteStudio/Communication/CommunicationWrapper.cs:line 34
   at CelesteStudio.Studio..ctor(String[] args, Action`1 windowCreationCallback) in /home/jakob/dev/celeste/celestetas/Studio/CelesteStudio/Studio.cs:line 242
   at CelesteStudio.GTK.Program.Main(String[] args) in /home/jakob/dev/celeste/celestetas/Studio/CelesteStudio.GTK/Program.cs:line 15

```