### PR TITLE
Fix completion with trailing whitespace

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2640,6 +2640,8 @@ public sealed class Editor : SkiaDrawable {
     private void OnDeleteSelectedLines() {
         using var __ = Document.Update();
 
+        ActivePopupMenu = null;
+
         int minRow = Document.Selection.Min.Row;
         int maxRow = Document.Selection.Max.Row;
         if (Document.Selection.Empty) {

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2762,8 +2762,8 @@ public sealed class Editor : SkiaDrawable {
                     continue; // Ignore
                 }
 
-                int hashIdx = line.IndexOf('#');
-                string newLine = FileRefactor.FormatLine(line.Remove(hashIdx, 1));
+                int hashIdx = lineTrimmed.IndexOf('#');
+                string newLine = FileRefactor.FormatLine(lineTrimmed.Remove(hashIdx, 1));
                 Document.ReplaceLine(row, newLine);
 
                 // Shift everything over
@@ -2843,7 +2843,6 @@ public sealed class Editor : SkiaDrawable {
             if (allCommented) {
                 int hashIdx = line.IndexOf('#');
                 string newLine = FileRefactor.FormatLine(line.Remove(hashIdx, 1));
-                Console.WriteLine($"{row} '{line}' -> '{newLine}'");
                 Document.ReplaceLine(row, newLine);
 
                 // Shift everything over

--- a/Studio/CelesteStudio/Editing/FileRefactor.cs
+++ b/Studio/CelesteStudio/Editing/FileRefactor.cs
@@ -54,8 +54,7 @@ public static class FileRefactor {
     }
     /// Applies formatting rules to the line
     public static string FormatLine(string line, bool? forceCommandCasing = null, string? commandSeparator = null) {
-        // Convert to action lines, if possible
-        if (ActionLine.TryParse(line, out var actionLine)) {
+        if (ActionLine.TryParseStrict(line, out var actionLine)) {
             return actionLine.ToString();
         }
         if (CommandLine.TryParse(line, out var commandLine)) {


### PR DESCRIPTION
While `console,load,` suggests 1 2 3 4 etc., `console load ` didn't. This is fixed by not trimming the trailing whitespace away when parsing the command line, because it is actually meaningful.

Also closes the popup when you `Ctrl-Y`.