### PR TITLE
editor: when moving caret, pick location based on selection

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -3179,6 +3179,14 @@ public sealed class Editor : SkiaDrawable {
     }
 
     private void MoveCaret(CaretMovementType direction, bool updateSelection) {
+        if (!Document.Selection.Empty && !updateSelection) {
+            Document.Caret = direction switch {
+                CaretMovementType.CharRight or CaretMovementType.LineDown => Document.Selection.Max,
+                CaretMovementType.CharLeft or CaretMovementType.LineUp => Document.Selection.Min,
+                _ => Document.Caret,
+            };
+        }
+        
         string line = Document.Lines[Document.Caret.Row];
         var oldCaret = Document.Caret;
 

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -3181,12 +3181,12 @@ public sealed class Editor : SkiaDrawable {
     private void MoveCaret(CaretMovementType direction, bool updateSelection) {
         if (!Document.Selection.Empty && !updateSelection) {
             Document.Caret = direction switch {
-                CaretMovementType.CharRight or CaretMovementType.LineDown => Document.Selection.Max,
-                CaretMovementType.CharLeft or CaretMovementType.LineUp => Document.Selection.Min,
+                CaretMovementType.CharLeft  or CaretMovementType.WordLeft  or CaretMovementType.LineUp   or CaretMovementType.PageUp   or CaretMovementType.LabelUp   or CaretMovementType.LineStart => Document.Selection.Min,
+                CaretMovementType.CharRight or CaretMovementType.WordRight or CaretMovementType.LineDown or CaretMovementType.PageDown or CaretMovementType.LabelDown or CaretMovementType.LineEnd   => Document.Selection.Max,
                 _ => Document.Caret,
             };
         }
-        
+
         string line = Document.Lines[Document.Caret.Row];
         var oldCaret = Document.Caret;
 


### PR DESCRIPTION
Changes it so that when you move up here, the caret moves to line 11 instead of line 20.
![image of studio with a selection](https://github.com/user-attachments/assets/a4c750de-166c-42b9-a85f-0b4048858b95)

I'm not sure whether this is universally preferred. Of course you could add a preference for this, but I'd prefer adding preferences only if people actually use them.

**Current Behaviour**: Notepad
**New Behaviour**: Rider, VS Code, Visual Studio, Google Docs, Word