### PR TITLE
Improvements to target query

### DIFF
--- a/CelesteTAS-EverestInterop/Source/InfoHUD/TargetQuery.cs
+++ b/CelesteTAS-EverestInterop/Source/InfoHUD/TargetQuery.cs
@@ -134,19 +134,20 @@ public static class TargetQuery {
                 // Use '.' instead of '+' for nested types
                 fullName = fullName.Replace('+', '.');
 
-                // Strip namespace
-                int namespaceLen = type.Namespace != null
-                    ? type.Namespace.Length + 1
-                    : 0;
-                string shortName = fullName[namespaceLen..];
-
                 AllTypes.AddToKey(fullName, type);
                 AllTypes.AddToKey($"{fullName}@{assemblyName}", type);
                 AllTypes.AddToKey($"{fullName}@{modName}", type);
 
-                AllTypes.AddToKey(shortName, type);
-                AllTypes.AddToKey($"{shortName}@{assemblyName}", type);
-                AllTypes.AddToKey($"{shortName}@{modName}", type);
+                // Strip namespace
+                if (type.Namespace != null) {
+                    int namespaceLen = type.Namespace != null
+                        ? type.Namespace.Length + 1
+                        : 0;
+                    string shortName = fullName[namespaceLen..];
+                    AllTypes.AddToKey(shortName, type);
+                    AllTypes.AddToKey($"{shortName}@{assemblyName}", type);
+                    AllTypes.AddToKey($"{shortName}@{modName}", type);
+                }
             }
         }
     }


### PR DESCRIPTION
**Namespaceless types:**
- Previously they would be added twice into `AllTypes`, and any type that exists twice is never autocompleted (this could also be improved).
- now they're autocompleted as well

I know they aren't really used in celeste, but in unity I think it is more common that the namespaceless types are usually the actual game types so they should be displayed first.
In celeste, apparently only `FlagDateTrigger` (modded?) is namespaceless.
![image](https://github.com/user-attachments/assets/c5718b52-cac8-44ae-809a-4b7ed10b94f3)

**Invoke can call overload based on arity**

If there are both
```
void ChangeState(State newState);
void ChangeState(State newState, State fallback);
```
calling `Invoke` would previously throw an `AmbiguousMatch` exception. Now `Invoke, MonsterBase.ChangeStateIfValid, Attack8` works as expected.