### PR TITLE
fix crash when choosing enum entry in menu

### DIFF
--- a/Studio/CelesteStudio/Bindings.cs
+++ b/Studio/CelesteStudio/Bindings.cs
@@ -105,7 +105,8 @@ public record EnumBinding<T>(string identifier, string DisplayName, Dictionary<T
         for (int i = 0; i < selector.Items.Count; i++) {
             var item = (RadioMenuItem)selector.Items[i];
             item.Checked = i == currIdx;
-            item.Click += (_, _) => SetValue(values[i]);
+            var valueIndex = i;
+            item.Click += (_, _) => SetValue(values[valueIndex]);
         }
 
         return selector;


### PR DESCRIPTION
I'm always getting an indexoutofbounds exception when selecting the popup menu mode.
The index was captured by reference, copying it to a local variable fixes the issue.


Actually looking back at the code I don't understand how it resulted in arrayinfexoutofbounds instead of just always picking the latest value 🤔 