### PR TITLE
fix: don't always try to migrate on same version number

### DIFF
--- a/Studio/CelesteStudio/Migration/Migrator.cs
+++ b/Studio/CelesteStudio/Migration/Migrator.cs
@@ -57,10 +57,8 @@ public static class Migrator {
             newCelesteTasVersion = InvalidVersion;
             newStudioVersion = Assembly.GetExecutingAssembly().GetName().Version!;
         }
-
-        // get rid of major.minor.build.0 revision
-        newStudioVersion = new Version(newStudioVersion.Major, newStudioVersion.Minor, newStudioVersion.Build);
 #endif
+
         if (firstV3Launch) {
             if (studioV2Present) {
                 oldStudioVersion = new Version(2, 0, 0);
@@ -80,6 +78,13 @@ public static class Migrator {
                 ? celesteTasVersion
                 : new Version(3, 43, 8); // Latest version before it was stored in the file
         }
+
+        // Force a revision of 0 to avoid issues when comparing
+        oldCelesteTasVersion = new Version(oldCelesteTasVersion.Major, oldCelesteTasVersion.Minor, oldCelesteTasVersion.Build, revision: 0);
+        newCelesteTasVersion = new Version(newCelesteTasVersion.Major, newCelesteTasVersion.Minor, newCelesteTasVersion.Build, revision: 0);
+        oldStudioVersion = new Version(oldStudioVersion.Major, oldStudioVersion.Minor, oldStudioVersion.Build, revision: 0);
+        newStudioVersion = new Version(newStudioVersion.Major, newStudioVersion.Minor, newStudioVersion.Build, revision: 0);
+
 #if DEBUG
         // Always apply the next migration in debug builds
         if (migrations[^2].Version < oldStudioVersion && newStudioVersion == migrations[^1].Version) {

--- a/Studio/CelesteStudio/Migration/Migrator.cs
+++ b/Studio/CelesteStudio/Migration/Migrator.cs
@@ -57,6 +57,9 @@ public static class Migrator {
             newCelesteTasVersion = InvalidVersion;
             newStudioVersion = Assembly.GetExecutingAssembly().GetName().Version!;
         }
+
+        // get rid of major.minor.build.0 revision
+        newStudioVersion = new Version(newStudioVersion.Major, newStudioVersion.Minor, newStudioVersion.Build);
 #endif
         if (firstV3Launch) {
             if (studioV2Present) {


### PR DESCRIPTION
The studio version written to file is `3.9.3` which gets parsed into a `Version` with `Revsision=-1`.
The version read from the assembly however is `3.9.3.0`, which compares greater than `3.9.3(.-1)`.