### PR TITLE
use png as app icon

### DIFF
--- a/Studio/CelesteStudio/Assets.cs
+++ b/Studio/CelesteStudio/Assets.cs
@@ -5,7 +5,7 @@ namespace CelesteStudio;
 
 public static class Assets {
 
-    public static Icon AppIcon = Icon.FromResource("Icon.ico");
+    public static Icon AppIcon = Icon.FromResource("Icon.png");
 
     public static readonly SKPath CollapseOpenPath = CreateVectorPath(new(0.0f, 0.0f), new(1.0f, 0.0f), new(0.5f, 1.0f));
     public static readonly SKPath CollapseClosedPath = CreateVectorPath(new(0.0f, 0.0f), new(1.0f, 0.5f), new(0.0f, 1.0f));

--- a/Studio/CelesteStudio/CelesteStudio.csproj
+++ b/Studio/CelesteStudio/CelesteStudio.csproj
@@ -37,6 +37,7 @@
 
     <ItemGroup>
         <EmbeddedResource Include="Assets\Icon.ico" LogicalName="Icon.ico"/>
+        <EmbeddedResource Include="..\..\Assets\icon.png" LogicalName="Icon.png"/>
     </ItemGroup>
 
     <!-- Windows requires .otf, macOS requires .ttf and GTK doesn't seem to care -->


### PR DESCRIPTION
fixes crash on linux due to Gdk not supporting ms ico images